### PR TITLE
Add initial table flattening

### DIFF
--- a/resultset.go
+++ b/resultset.go
@@ -1,5 +1,7 @@
 package aggro
 
+import "strings"
+
 type Resultset struct {
 	Errors  []error                  `json:"errors"`
 	Buckets map[string]*ResultBucket `json:"buckets"`
@@ -10,4 +12,90 @@ type ResultBucket struct {
 	Metrics    map[string]interface{}   `json:"metrics"`
 	Buckets    map[string]*ResultBucket `json:"buckets"`
 	sourceRows []map[string]Cell
+}
+
+// ResultTable represents a Resultset split into row / columns at a depth.
+type ResultTable struct {
+	Rows         [][]map[string]interface{} `json:"rows"`
+	RowTitles    [][]string                 `json:"row_titles"`
+	ColumnTitles [][]string                 `json:"column_titles"`
+}
+
+// Tabulate takes a Resultset and converts it to tabular data.
+func Tabulate(results *Resultset, depth int) (*ResultTable, error) {
+	// Create our table.
+	table := &ResultTable{
+		Rows:         [][]map[string]interface{}{},
+		RowTitles:    [][]string{},
+		ColumnTitles: [][]string{},
+	}
+
+	// And a lookup helper instance.
+	lookup := &resultLookup{
+		cells:        map[string]map[string]interface{}{},
+		rowLookup:    map[string]bool{},
+		columnLookup: map[string]bool{},
+	}
+
+	// Recursively build the lookup for each of the root result buckets.
+	for _, bucket := range results.Buckets {
+		buildLookup([]string{}, 1, depth, table, lookup, bucket)
+	}
+
+	// Now build up the cells for each of the row / column tuples.
+	for _, row := range table.RowTitles {
+		tableRow := []map[string]interface{}{}
+		for _, column := range table.ColumnTitles {
+			tableRow = append(tableRow, lookup.cells[strings.Join(row, lookupKeyDelimiter)+lookupKeyDelimiter+strings.Join(column, lookupKeyDelimiter)])
+		}
+		table.Rows = append(table.Rows, tableRow)
+	}
+	// And we're done 👌.
+	return table, nil
+}
+
+// resultLookup stores specific data as the result set is recursively iterated over.
+type resultLookup struct {
+	cells        map[string]map[string]interface{}
+	rowLookup    map[string]bool
+	columnLookup map[string]bool
+}
+
+// lookupKeyDelimiter is used to flatten a string array to a single key.
+const lookupKeyDelimiter = "🔑🗝😡🗝🔑"
+
+// buildLookup is a recursive function that breaks data into rows and columns
+// at a specific depth.
+func buildLookup(key []string, depth, targetDepth int, table *ResultTable, lookup *resultLookup, bucket *ResultBucket) {
+	// Add the new bucket value to the lookup key.
+	key = append(key, bucket.Value)
+
+	// If we have no buckets, we're at a metric point.
+	if len(bucket.Buckets) == 0 {
+		// The column key is made up of just the key parts from the target depth.
+		columnKey := strings.Join(key[targetDepth:], lookupKeyDelimiter)
+		// If we haven't seen this column tuple before, add it to the lookup.
+		if _, ok := lookup.columnLookup[columnKey]; !ok {
+			table.ColumnTitles = append(table.ColumnTitles, key[targetDepth:])
+			lookup.columnLookup[columnKey] = true
+		}
+		lookup.cells[strings.Join(key, lookupKeyDelimiter)] = bucket.Metrics
+		return
+	}
+
+	// If we've reached target depth, add this key to the rows if it's not there.
+	if depth == targetDepth {
+		rowKey := strings.Join(key, lookupKeyDelimiter)
+		if _, ok := lookup.rowLookup[rowKey]; !ok {
+			table.RowTitles = append(table.RowTitles, key)
+			lookup.rowLookup[rowKey] = true
+		}
+	}
+
+	// Now continue down the 🐇 hole with the next depth of result buckets.
+	for _, bucket := range bucket.Buckets {
+		newKey := make([]string, len(key))
+		copy(newKey, key)
+		buildLookup(newKey, depth+1, targetDepth, table, lookup, bucket)
+	}
 }

--- a/resultset_test.go
+++ b/resultset_test.go
@@ -1,0 +1,331 @@
+package aggro
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFlattenResultSetSimple(t *testing.T) {
+	RegisterTestingT(t)
+	expected := ResultTable{
+		Rows: [][]map[string]interface{}{
+			{
+				{
+					"salary:max": nil,
+				},
+				{
+					"salary:max": 150000,
+				},
+				{
+					"salary:max": 120000,
+				},
+			},
+			{
+				{
+					"salary:max": nil,
+				},
+				{
+					"salary:max": 120000,
+				},
+				{
+					"salary:max": 220000,
+				},
+			},
+		},
+		RowTitles: [][]string{
+			{"Auckland"},
+			{"Wellington"},
+		},
+		ColumnTitles: [][]string{
+			{"2015-12-01T00:00:00+13:00"},
+			{"2016-01-01T00:00:00+13:00"},
+			{"2016-02-01T00:00:00+13:00"},
+		},
+	}
+	input := &Resultset{
+		Buckets: map[string]*ResultBucket{
+			"Auckland": {
+				Value: "Auckland",
+				Buckets: map[string]*ResultBucket{
+					"2015-12-01T00:00:00+13:00": {
+						Value:   "2015-12-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": nil,
+						},
+					},
+					"2016-01-01T00:00:00+13:00": {
+						Value:   "2016-01-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": 150000,
+						},
+					},
+					"2016-02-01T00:00:00+13:00": {
+						Value:   "2016-02-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": 120000,
+						},
+					},
+				},
+			},
+			"Wellington": {
+				Value: "Wellington",
+				Buckets: map[string]*ResultBucket{
+					"2015-12-01T00:00:00+13:00": {
+						Value:   "2015-12-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": nil,
+						},
+					},
+					"2016-01-01T00:00:00+13:00": {
+						Value:   "2016-01-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": 120000,
+						},
+					},
+					"2016-02-01T00:00:00+13:00": {
+						Value:   "2016-02-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": 220000,
+						},
+					},
+				},
+			},
+		},
+	}
+	results, err := Tabulate(input, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error converting results: %s", err.Error())
+	}
+
+	rm, _ := json.MarshalIndent(*results, "", "  ")
+	em, _ := json.MarshalIndent(expected, "", "  ")
+	Expect(rm).To(MatchJSON(em))
+}
+
+func TestFlattenResultSetWithHoles(t *testing.T) {
+	RegisterTestingT(t)
+	expected := ResultTable{
+		Rows: [][]map[string]interface{}{
+			{
+				{
+					"salary:max": nil,
+				},
+				{
+					"salary:max": 150000,
+				},
+				nil,
+			},
+			{
+				{
+					"salary:max": nil,
+				},
+				nil,
+				{
+					"salary:max": 120000,
+				},
+			},
+		},
+		RowTitles: [][]string{
+			{"Auckland"},
+			{"Wellington"},
+		},
+		ColumnTitles: [][]string{
+			{"2015-12-01T00:00:00+13:00"},
+			{"2016-01-01T00:00:00+13:00"},
+			{"2016-02-01T00:00:00+13:00"},
+		},
+	}
+	input := &Resultset{
+		Buckets: map[string]*ResultBucket{
+			"Auckland": {
+				Value: "Auckland",
+				Buckets: map[string]*ResultBucket{
+					"2015-12-01T00:00:00+13:00": {
+						Value:   "2015-12-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": nil,
+						},
+					},
+					"2016-01-01T00:00:00+13:00": {
+						Value:   "2016-01-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": 150000,
+						},
+					},
+				},
+			},
+			"Wellington": {
+				Value: "Wellington",
+				Buckets: map[string]*ResultBucket{
+					"2015-12-01T00:00:00+13:00": {
+						Value:   "2015-12-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": nil,
+						},
+					},
+					"2016-02-01T00:00:00+13:00": {
+						Value:   "2016-02-01T00:00:00+13:00",
+						Buckets: map[string]*ResultBucket{},
+						Metrics: map[string]interface{}{
+							"salary:max": 120000,
+						},
+					},
+				},
+			},
+		},
+	}
+	results, err := Tabulate(input, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error converting results: %s", err.Error())
+	}
+
+	rm, _ := json.MarshalIndent(*results, "", "  ")
+	em, _ := json.MarshalIndent(expected, "", "  ")
+	Expect(rm).To(MatchJSON(em))
+}
+
+func TestFlattenResultDeep(t *testing.T) {
+	RegisterTestingT(t)
+	expected := ResultTable{
+		Rows: [][]map[string]interface{}{
+			{
+				{
+					"salary:max": 1111,
+				},
+				nil,
+				{
+					"salary:max": 1121,
+				},
+			},
+			{
+				{
+					"salary:max": 1211,
+				},
+				{
+					"salary:max": 1212,
+				},
+				nil,
+			},
+			{
+				nil,
+				nil,
+				{
+					"salary:max": 2321,
+				},
+			},
+		},
+		RowTitles: [][]string{
+			{"A1", "B1"},
+			{"A1", "B2"},
+			{"A2", "B3"},
+		},
+		ColumnTitles: [][]string{
+			{"C1", "D1"},
+			{"C1", "D2"},
+			{"C2", "D1"},
+		},
+	}
+	input := &Resultset{
+		Buckets: map[string]*ResultBucket{
+			"A1": {
+				Value: "A1",
+				Buckets: map[string]*ResultBucket{
+					"B1": {
+						Value: "B1",
+						Buckets: map[string]*ResultBucket{
+							"C1": {
+								Value: "C1",
+								Buckets: map[string]*ResultBucket{
+									"D1": {
+										Value:   "D1",
+										Buckets: map[string]*ResultBucket{},
+										Metrics: map[string]interface{}{
+											"salary:max": 1111,
+										},
+									},
+								},
+							},
+							"C2": {
+								Value: "C2",
+								Buckets: map[string]*ResultBucket{
+									"D1": {
+										Value:   "D1",
+										Buckets: map[string]*ResultBucket{},
+										Metrics: map[string]interface{}{
+											"salary:max": 1121,
+										},
+									},
+								},
+							},
+						},
+					},
+					"B2": {
+						Value: "B2",
+						Buckets: map[string]*ResultBucket{
+							"C1": {
+								Value: "C1",
+								Buckets: map[string]*ResultBucket{
+									"D1": {
+										Value:   "D1",
+										Buckets: map[string]*ResultBucket{},
+										Metrics: map[string]interface{}{
+											"salary:max": 1211,
+										},
+									},
+									"D2": {
+										Value:   "D2",
+										Buckets: map[string]*ResultBucket{},
+										Metrics: map[string]interface{}{
+											"salary:max": 1212,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"A2": {
+				Value: "A2",
+				Buckets: map[string]*ResultBucket{
+					"B3": {
+						Value: "B3",
+						Buckets: map[string]*ResultBucket{
+							"C2": {
+								Value: "C2",
+								Buckets: map[string]*ResultBucket{
+									"D1": {
+										Value:   "D1",
+										Buckets: map[string]*ResultBucket{},
+										Metrics: map[string]interface{}{
+											"salary:max": 2321,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	results, err := Tabulate(input, 2)
+	if err != nil {
+		t.Fatalf("Unexpected error converting results: %s", err.Error())
+	}
+
+	rm, _ := json.MarshalIndent(*results, "", "  ")
+	em, _ := json.MarshalIndent(expected, "", "  ")
+	Expect(rm).To(MatchJSON(em))
+}

--- a/resultset_test.go
+++ b/resultset_test.go
@@ -329,3 +329,40 @@ func TestFlattenResultDeep(t *testing.T) {
 	em, _ := json.MarshalIndent(expected, "", "  ")
 	Expect(rm).To(MatchJSON(em))
 }
+
+func TestTabulateDepthTooHigh(t *testing.T) {
+	input := &Resultset{
+		Buckets: map[string]*ResultBucket{
+			"A1": {
+				Value: "A1",
+				Buckets: map[string]*ResultBucket{
+					"B1": {
+						Value: "B1",
+						Buckets: map[string]*ResultBucket{
+							"C1": {
+								Value: "C1",
+								Buckets: map[string]*ResultBucket{
+									"D1": {
+										Value:   "D1",
+										Buckets: map[string]*ResultBucket{},
+										Metrics: map[string]interface{}{
+											"salary:max": 1111,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := Tabulate(input, 0)
+	if err != ErrTargetDepthTooLow {
+		t.Fatalf("Expected error converting results, got none")
+	}
+	_, err = Tabulate(input, 4)
+	if err != ErrTargetDepthNotReached {
+		t.Fatalf("Expected error converting results, got none")
+	}
+}


### PR DESCRIPTION
This seems to be working ok, however has highlighted the lack of sorting in our initial result set implementation. Being a map, it's unable to retain ordering. This probably isn't an issue, as what we could be doing now is working out how we want to be able to sort and filter data (sort by mean, 10 results only) sorta thing.

Not sure where that would live as given a "table" you may want to sort on a total (i.e. the row). This is easy to do for max etc. however average wouldn't be possible without valueCount for example.

May need a think, but we can merge this in the meantime, just the tests are flaky because the input is non deterministic (maps don't order).