### PR TITLE
Add initial alphabetical sorting option 📚

### DIFF
--- a/query.go
+++ b/query.go
@@ -2,11 +2,13 @@ package aggro
 
 import "time"
 
+// Query represents the bucketing and aggregate metrics that should be run.
 type Query struct {
 	Bucket  *Bucket
 	Metrics []Metric
 }
 
+// Bucket defines how to compare and group data which is then aggregated on.
 type Bucket struct {
 	Bucket          *Bucket
 	Field           *Field
@@ -14,6 +16,7 @@ type Bucket struct {
 	Sort            *SortOptions
 }
 
+// SortOptions represent how this Bucket should be sorted.
 type SortOptions struct {
 	Type   string
 	Metric string

--- a/query.go
+++ b/query.go
@@ -11,6 +11,13 @@ type Bucket struct {
 	Bucket          *Bucket
 	Field           *Field
 	DatetimeOptions *DatetimeBucketOptions
+	Sort            *SortOptions
+}
+
+type SortOptions struct {
+	Type   string
+	Metric string
+	Desc   bool
 }
 
 // DatetimeBucketOptions provides additional configuration for datetime bucketing.

--- a/resultset.go
+++ b/resultset.go
@@ -6,15 +6,16 @@ import (
 )
 
 type Resultset struct {
-	Errors  []error                  `json:"errors"`
-	Buckets map[string]*ResultBucket `json:"buckets"`
+	Errors  []error         `json:"errors"`
+	Buckets []*ResultBucket `json:"buckets"`
 }
 
 type ResultBucket struct {
-	Value      string                   `json:"value"`
-	Metrics    map[string]interface{}   `json:"metrics"`
-	Buckets    map[string]*ResultBucket `json:"buckets"`
-	sourceRows []map[string]Cell
+	Value        string                 `json:"value"`
+	Metrics      map[string]interface{} `json:"metrics"`
+	Buckets      []*ResultBucket        `json:"buckets"`
+	bucketLookup map[string]*ResultBucket
+	sourceRows   []map[string]Cell
 }
 
 // ResultTable represents a Resultset split into row / columns at a depth.
@@ -24,6 +25,7 @@ type ResultTable struct {
 	ColumnTitles [][]string                 `json:"column_titles"`
 }
 
+// Concrete errors.
 var (
 	ErrTargetDepthTooLow     = fmt.Errorf("Tabulate: target depth should be 1 or above.")
 	ErrTargetDepthNotReached = fmt.Errorf("Tabulate: reached deepest bucket before hitting target depth.")

--- a/resultset.go
+++ b/resultset.go
@@ -78,7 +78,7 @@ type resultLookup struct {
 }
 
 // lookupKeyDelimiter is used to flatten a string array to a single key.
-const lookupKeyDelimiter = "🔑🗝😡🗝🔑"
+const lookupKeyDelimiter = "😡"
 
 // buildLookup is a recursive function that breaks data into rows and columns
 // at a specific depth.

--- a/resultset_test.go
+++ b/resultset_test.go
@@ -45,53 +45,53 @@ func TestFlattenResultSetSimple(t *testing.T) {
 		},
 	}
 	input := &Resultset{
-		Buckets: map[string]*ResultBucket{
-			"Auckland": {
+		Buckets: []*ResultBucket{
+			{
 				Value: "Auckland",
-				Buckets: map[string]*ResultBucket{
-					"2015-12-01T00:00:00+13:00": {
-						Value:   "2015-12-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+				Buckets: []*ResultBucket{
+					{
+						Value: "2015-12-01T00:00:00+13:00",
+						// Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": nil,
 						},
 					},
-					"2016-01-01T00:00:00+13:00": {
-						Value:   "2016-01-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+					{
+						Value: "2016-01-01T00:00:00+13:00",
+						// Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": 150000,
 						},
 					},
-					"2016-02-01T00:00:00+13:00": {
+					{
 						Value:   "2016-02-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": 120000,
 						},
 					},
 				},
 			},
-			"Wellington": {
+			{
 				Value: "Wellington",
-				Buckets: map[string]*ResultBucket{
-					"2015-12-01T00:00:00+13:00": {
+				Buckets: []*ResultBucket{
+					{
 						Value:   "2015-12-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": nil,
 						},
 					},
-					"2016-01-01T00:00:00+13:00": {
+					{
 						Value:   "2016-01-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": 120000,
 						},
 					},
-					"2016-02-01T00:00:00+13:00": {
+					{
 						Value:   "2016-02-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": 220000,
 						},
@@ -144,39 +144,39 @@ func TestFlattenResultSetWithHoles(t *testing.T) {
 		},
 	}
 	input := &Resultset{
-		Buckets: map[string]*ResultBucket{
-			"Auckland": {
+		Buckets: []*ResultBucket{
+			{
 				Value: "Auckland",
-				Buckets: map[string]*ResultBucket{
-					"2015-12-01T00:00:00+13:00": {
+				Buckets: []*ResultBucket{
+					{
 						Value:   "2015-12-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": nil,
 						},
 					},
-					"2016-01-01T00:00:00+13:00": {
+					{
 						Value:   "2016-01-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": 150000,
 						},
 					},
 				},
 			},
-			"Wellington": {
+			{
 				Value: "Wellington",
-				Buckets: map[string]*ResultBucket{
-					"2015-12-01T00:00:00+13:00": {
+				Buckets: []*ResultBucket{
+					{
 						Value:   "2015-12-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": nil,
 						},
 					},
-					"2016-02-01T00:00:00+13:00": {
+					{
 						Value:   "2016-02-01T00:00:00+13:00",
-						Buckets: map[string]*ResultBucket{},
+						Buckets: []*ResultBucket{},
 						Metrics: map[string]interface{}{
 							"salary:max": 120000,
 						},
@@ -203,26 +203,26 @@ func TestFlattenResultDeep(t *testing.T) {
 				{
 					"salary:max": 1111,
 				},
-				nil,
 				{
 					"salary:max": 1121,
 				},
+				nil,
 			},
 			{
 				{
 					"salary:max": 1211,
 				},
+				nil,
 				{
 					"salary:max": 1212,
 				},
-				nil,
 			},
 			{
-				nil,
 				nil,
 				{
 					"salary:max": 2321,
 				},
+				nil,
 			},
 		},
 		RowTitles: [][]string{
@@ -232,36 +232,36 @@ func TestFlattenResultDeep(t *testing.T) {
 		},
 		ColumnTitles: [][]string{
 			{"C1", "D1"},
-			{"C1", "D2"},
 			{"C2", "D1"},
+			{"C1", "D2"},
 		},
 	}
 	input := &Resultset{
-		Buckets: map[string]*ResultBucket{
-			"A1": {
+		Buckets: []*ResultBucket{
+			{
 				Value: "A1",
-				Buckets: map[string]*ResultBucket{
-					"B1": {
+				Buckets: []*ResultBucket{
+					{
 						Value: "B1",
-						Buckets: map[string]*ResultBucket{
-							"C1": {
+						Buckets: []*ResultBucket{
+							{
 								Value: "C1",
-								Buckets: map[string]*ResultBucket{
-									"D1": {
+								Buckets: []*ResultBucket{
+									{
 										Value:   "D1",
-										Buckets: map[string]*ResultBucket{},
+										Buckets: []*ResultBucket{},
 										Metrics: map[string]interface{}{
 											"salary:max": 1111,
 										},
 									},
 								},
 							},
-							"C2": {
+							{
 								Value: "C2",
-								Buckets: map[string]*ResultBucket{
-									"D1": {
+								Buckets: []*ResultBucket{
+									{
 										Value:   "D1",
-										Buckets: map[string]*ResultBucket{},
+										Buckets: []*ResultBucket{},
 										Metrics: map[string]interface{}{
 											"salary:max": 1121,
 										},
@@ -270,22 +270,22 @@ func TestFlattenResultDeep(t *testing.T) {
 							},
 						},
 					},
-					"B2": {
+					{
 						Value: "B2",
-						Buckets: map[string]*ResultBucket{
-							"C1": {
+						Buckets: []*ResultBucket{
+							{
 								Value: "C1",
-								Buckets: map[string]*ResultBucket{
-									"D1": {
+								Buckets: []*ResultBucket{
+									{
 										Value:   "D1",
-										Buckets: map[string]*ResultBucket{},
+										Buckets: []*ResultBucket{},
 										Metrics: map[string]interface{}{
 											"salary:max": 1211,
 										},
 									},
-									"D2": {
+									{
 										Value:   "D2",
-										Buckets: map[string]*ResultBucket{},
+										Buckets: []*ResultBucket{},
 										Metrics: map[string]interface{}{
 											"salary:max": 1212,
 										},
@@ -296,18 +296,18 @@ func TestFlattenResultDeep(t *testing.T) {
 					},
 				},
 			},
-			"A2": {
+			{
 				Value: "A2",
-				Buckets: map[string]*ResultBucket{
-					"B3": {
+				Buckets: []*ResultBucket{
+					{
 						Value: "B3",
-						Buckets: map[string]*ResultBucket{
-							"C2": {
+						Buckets: []*ResultBucket{
+							{
 								Value: "C2",
-								Buckets: map[string]*ResultBucket{
-									"D1": {
+								Buckets: []*ResultBucket{
+									{
 										Value:   "D1",
-										Buckets: map[string]*ResultBucket{},
+										Buckets: []*ResultBucket{},
 										Metrics: map[string]interface{}{
 											"salary:max": 2321,
 										},
@@ -332,19 +332,19 @@ func TestFlattenResultDeep(t *testing.T) {
 
 func TestTabulateDepthTooHigh(t *testing.T) {
 	input := &Resultset{
-		Buckets: map[string]*ResultBucket{
-			"A1": {
+		Buckets: []*ResultBucket{
+			{
 				Value: "A1",
-				Buckets: map[string]*ResultBucket{
-					"B1": {
+				Buckets: []*ResultBucket{
+					{
 						Value: "B1",
-						Buckets: map[string]*ResultBucket{
-							"C1": {
+						Buckets: []*ResultBucket{
+							{
 								Value: "C1",
-								Buckets: map[string]*ResultBucket{
-									"D1": {
+								Buckets: []*ResultBucket{
+									{
 										Value:   "D1",
-										Buckets: map[string]*ResultBucket{},
+										Buckets: []*ResultBucket{},
 										Metrics: map[string]interface{}{
 											"salary:max": 1111,
 										},

--- a/sort.go
+++ b/sort.go
@@ -1,9 +1,16 @@
 package aggro
 
+// Sortable provides an interface that various sorters can implement to compare
+// two result buckets. This enables access to both the value and any metrics
+// that the query may have contained.
 type Sortable interface {
 	Less(a, b *ResultBucket) bool
 }
 
+// sortableForOptions returns the appropriate sorter for the supplied sort
+// options. If the options type provided is invalid, it is ignored an no sorter
+// is returned. A nil response here will end up with results being in a
+// non-deterministic order due to randomisation when ranging over maps.
 func sortableForOptions(options *SortOptions) Sortable {
 	if options == nil {
 		return nil
@@ -16,8 +23,11 @@ func sortableForOptions(options *SortOptions) Sortable {
 	return nil
 }
 
+// AlphabeticalSortable is a simple  sorter that sorts alphabetically in the
+// direction of the boolean, true meaning ascending and false being descending.
 type AlphabeticalSortable bool
 
+// Less implements Sortable by comparing the values field of each result.
 func (sortable *AlphabeticalSortable) Less(a, b *ResultBucket) bool {
 	return a.Value < b.Value == bool(*sortable)
 }

--- a/sort.go
+++ b/sort.go
@@ -9,8 +9,8 @@ type Sortable interface {
 	Less(a, b *ResultBucket) bool
 }
 
-// sortableForOptions returns the appropriate sorter for the supplied sort
-// options. If the options type provided is invalid, it is ignored an no sorter
+// sortableForOptions returns the sortable implementation for the supplied sort
+// options. If the options type provided is invalid, it is ignored and no sorter
 // is returned. A nil response here will end up with results being in a
 // non-deterministic order due to randomisation when ranging over maps.
 func sortableForOptions(options *SortOptions) Sortable {
@@ -25,17 +25,17 @@ func sortableForOptions(options *SortOptions) Sortable {
 	return nil
 }
 
-// AlphabeticalSortable is a simple  sorter that sorts alphabetically in the
+// AlphabeticalSortable is a simple sorter that sorts alphabetically in the
 // direction of the boolean, true meaning ascending and false being descending.
 type AlphabeticalSortable bool
 
-// Less implements Sortable by comparing the values field of each result.
+// Less implements Sortable by comparing the value field of each result.
 func (sortable *AlphabeticalSortable) Less(a, b *ResultBucket) bool {
 	return a.Value < b.Value == bool(*sortable)
 }
 
 // bucketSorter is an implementation of the sort.Sort interface that is capable
-// or sorting the supplied slice of results with the supplied Sortable.
+// of sorting the supplied slice of results with the supplied Sortable.
 type bucketSorter struct {
 	results  []*ResultBucket
 	sortable Sortable
@@ -51,7 +51,7 @@ func (sorter *bucketSorter) Swap(i, j int) {
 	sorter.results[i], sorter.results[j] = sorter.results[j], sorter.results[i]
 }
 
-// Less implement the sort.Sort less method by calling the Sortable that the
+// Less implements the sort.Sort Less method by calling the Sortable that the
 // sorter has been supplied, with the two appropriate results.
 func (sorter *bucketSorter) Less(i, j int) bool {
 	return sorter.sortable.Less(sorter.results[i], sorter.results[j])

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,23 @@
+package aggro
+
+type Sortable interface {
+	Less(a, b *ResultBucket) bool
+}
+
+func sortableForOptions(options *SortOptions) Sortable {
+	if options == nil {
+		return nil
+	}
+	switch options.Type {
+	case "alphabetical":
+		s := AlphabeticalSortable(!options.Desc)
+		return &s
+	}
+	return nil
+}
+
+type AlphabeticalSortable bool
+
+func (sortable *AlphabeticalSortable) Less(a, b *ResultBucket) bool {
+	return a.Value < b.Value == bool(*sortable)
+}


### PR DESCRIPTION
Adds an additional field to buckets that is used to sort on. Currently the only implementation is an alphabetical sorter on the field value. Adding the ability to sort on metrics is an easy next step.

```go
query := &Query{
		Metrics: []Metric{
			{Type: "mean", Field: "salary"},
			{Type: "max", Field: "salary"},
			{Type: "min", Field: "salary"},
		},
		Bucket: &Bucket{
			Field: &Field{
				Name: "location",
				Type: "string",
			},
			Sort: &SortOptions{
				Type: "alphabetical",
			},
			Bucket: &Bucket{
				Field: &Field{
					Name: "start_date",
					Type: "datetime",
				},
				Sort: &SortOptions{
					Type: "alphabetical",
					Desc: true,
				},
			},
		},
	}
```