### PR TITLE
Custom Ranges

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -146,6 +146,12 @@ func (cell *NumberCell) MeasurableCell() MeasurableCell {
 	return cell
 }
 
+// ValueForPeriod returns the start of a given period.
+func (cell *NumberCell) ValueForPeriod(period []interface{}) (string, error) {
+	value, err := rangeValueForPeriod(cell.value, period)
+	return value.String(), err
+}
+
 type DatetimeCell struct {
 	value *time.Time
 	field *Field

--- a/processor.go
+++ b/processor.go
@@ -262,14 +262,8 @@ func (p *queryProcessor) fillBucketRangeGaps(bucket *Bucket, results map[string]
 			switch i := p.(type) {
 			case float64:
 				v = i
-			case float32:
-				v = float64(i)
-			case int32:
-				v = float64(i)
-			case int64:
-				v = float64(i)
-			case int:
-				v = float64(i)
+			case float32, int, int32, int64:
+				v = i.(float64)
 			}
 
 			// Make sure this period exists.

--- a/processor.go
+++ b/processor.go
@@ -262,8 +262,14 @@ func (p *queryProcessor) fillBucketRangeGaps(bucket *Bucket, results map[string]
 			switch i := p.(type) {
 			case float64:
 				v = i
-			case float32, int, int32, int64:
-				v = i.(float64)
+			case float32:
+				v = float64(i)
+			case int32:
+				v = float64(i)
+			case int64:
+				v = float64(i)
+			case int:
+				v = float64(i)
 			}
 
 			// Make sure this period exists.

--- a/query.go
+++ b/query.go
@@ -14,6 +14,7 @@ type Bucket struct {
 	Field           *Field
 	DatetimeOptions *DatetimeBucketOptions
 	Sort            *SortOptions
+	RangeOptions    *RangeBucketOptions
 }
 
 // SortOptions represent how this Bucket should be sorted.
@@ -33,4 +34,9 @@ type DatetimeBucketOptions struct {
 	Period DatetimePeriod
 	// Datetimes should be bucketed based on the date in this location.
 	Location *time.Location
+}
+
+// RangeBucketOptions provides additional configuration for custom range bucketing.
+type RangeBucketOptions struct {
+	Period []interface{}
 }

--- a/range.go
+++ b/range.go
@@ -1,0 +1,59 @@
+package aggro
+
+import (
+	"errors"
+
+	"github.com/shopspring/decimal"
+)
+
+func rangeValueForPeriod(value *decimal.Decimal, period []interface{}) (decimal.Decimal, error) {
+	var rangeVal decimal.Decimal
+
+	// Range each of the intervals (periods), determining which band the value
+	// falls into.
+	for i, p := range period {
+		var nextPeriodValue *decimal.Decimal
+
+		var v float64
+		switch i := p.(type) {
+		case float64:
+			v = i
+		case float32:
+			v = float64(i)
+		case int32:
+			v = float64(i)
+		case int64:
+			v = float64(i)
+		case int:
+			v = float64(i)
+		default:
+			return decimal.NewFromFloat(0.0), errors.New("Invalid range values supplied - NaN")
+		}
+
+		periodVal := decimal.NewFromFloat(v)
+
+		// Find the i+1 value in our range (if length of range allows it).
+		if len(period) < i {
+			nxt := decimal.NewFromFloat(period[i+1].(float64))
+			nextPeriodValue = &nxt
+		}
+
+		// Value equals one of our range bands exactly, return it.
+		if (periodVal).Equals(*value) {
+			return periodVal, nil
+		}
+
+		// Value is > than our current range value, but < than the next.
+		if (periodVal).Cmp(*value) > -1 {
+			if nextPeriodValue != nil {
+				if (nextPeriodValue).Cmp(*value) < 0 {
+					return periodVal, nil
+				}
+			} else {
+				return periodVal, nil
+			}
+		}
+	}
+
+	return rangeVal, nil
+}

--- a/range.go
+++ b/range.go
@@ -18,8 +18,14 @@ func rangeValueForPeriod(value *decimal.Decimal, period []interface{}) (decimal.
 		switch i := p.(type) {
 		case float64:
 			v = i
-		case float32, int, int32, int64:
-			v = i.(float64)
+		case float32:
+			v = float64(i)
+		case int32:
+			v = float64(i)
+		case int64:
+			v = float64(i)
+		case int:
+			v = float64(i)
 		default:
 			return decimal.NewFromFloat(0.0), errors.New("Invalid range values supplied - NaN")
 		}

--- a/range.go
+++ b/range.go
@@ -18,14 +18,8 @@ func rangeValueForPeriod(value *decimal.Decimal, period []interface{}) (decimal.
 		switch i := p.(type) {
 		case float64:
 			v = i
-		case float32:
-			v = float64(i)
-		case int32:
-			v = float64(i)
-		case int64:
-			v = float64(i)
-		case int:
-			v = float64(i)
+		case float32, int, int32, int64:
+			v = i.(float64)
 		default:
 			return decimal.NewFromFloat(0.0), errors.New("Invalid range values supplied - NaN")
 		}

--- a/sort.go
+++ b/sort.go
@@ -1,6 +1,9 @@
 package aggro
 
-import "sort"
+import (
+	"sort"
+	"strconv"
+)
 
 // Sortable provides an interface that various sorters can implement to compare
 // two result buckets. This enables access to both the value and any metrics
@@ -21,6 +24,9 @@ func sortableForOptions(options *SortOptions) Sortable {
 	case "alphabetical":
 		s := AlphabeticalSortable(!options.Desc)
 		return &s
+	case "numerical":
+		s := NumericalSortable(!options.Desc)
+		return &s
 	}
 	return nil
 }
@@ -32,6 +38,18 @@ type AlphabeticalSortable bool
 // Less implements Sortable by comparing the value field of each result.
 func (sortable *AlphabeticalSortable) Less(a, b *ResultBucket) bool {
 	return a.Value < b.Value == bool(*sortable)
+}
+
+// NumericalSortable is a simple sorter that sorts numerically in the
+// direction of the boolean, true meaning ascending and false being descending.
+type NumericalSortable bool
+
+// Less implements Sortable by comparing the value field of each result.
+func (sortable *NumericalSortable) Less(a, b *ResultBucket) bool {
+	// Cast bucket.Value (str) to float for comparison.
+	a1, _ := strconv.ParseFloat(a.Value, 64)
+	b1, _ := strconv.ParseFloat(b.Value, 64)
+	return a1 < b1 == bool(*sortable)
 }
 
 // bucketSorter is an implementation of the sort.Sort interface that is capable


### PR DESCRIPTION
This introduces custom ranges. 

**An example:**

```go
query := &Query{
		Metrics: []Metric{
			{Type: "count", Field: "salary"},
		},
		Bucket: &Bucket{
			Field: &Field{
				Name: "location",
				Type: "string",
			},
			Sort: &SortOptions{
				Type: "alphabetical",
			},
			Bucket: &Bucket{
				Field: &Field{
					Name: "salary",
					Type: "number",
				},
				RangeOptions: &RangeBucketOptions{
					Period: []interface{}{
						20000,
						50000,
						100000,
						150000,
						200000,
						300000,
					},
				},
				Sort: &SortOptions{
					Type: "numerical",
					Desc: false,
				},
			},
		},
	}
```

As part of this, I've also added a numerical sorter, which helps in returning the custom range results in desired order.