### PR TITLE
Boolean Datatypes, Commeting/Tidy and Addition of Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,84 @@
 # aggro 😡
 
+[![GoDoc](https://godoc.org/github.com/snikch/aggro?status.svg)](https://godoc.org/github.com/snikch/aggro)
+[![Go Report Card](https://goreportcard.com/badge/github.com/snikch/aggro)](https://goreportcard.com/report/github.com/snikch/aggro)
+
 In memory dataset bucketing and metrics, inspired by Elasticsearch aggregations
 
-See [test case](https://github.com/snikch/aggro/blob/master/aggro_test.go).
+Installation
+-----------------
 
-This is alpha software.
+`go get -u github.com/snikch/aggro`
+
+Example
+-------------
+
+Given a dataset...
+
+```go
+rows := []map[string]interface{}{
+		{"location": "Auckland", "department": "Engineering", "salary": 120000, "start_date": "2016-01-31T22:00:00Z"},
+		{"location": "Auckland", "department": "Engineering", "salary": 80000, "start_date": "2016-03-23T22:00:00Z"},
+		{"location": "Auckland", "department": "Marketing", "salary": 90000, "start_date": "2016-01-31T22:00:00Z"},
+		{"location": "Auckland", "department": "Marketing", "salary": 150000, "start_date": "2016-01-23T22:00:00Z"},
+		{"location": "Wellington", "department": "Engineering", "salary": 120000, "start_date": "2016-01-23T22:00:00Z"},
+		{"location": "Wellington", "department": "Engineering", "salary": 160000, "start_date": "2016-03-23T22:00:00Z"},
+		{"location": "Wellington", "department": "Engineering", "salary": 120000, "start_date": "2016-02-02T22:00:00Z"},
+	}
+```
+
+Initialize aggro, build aggregations and run...
+
+```go
+// Build a dataset that contains a *Table representing your data.
+dataset := &Dataset{
+	Table: &Table{
+		Fields: []Field{
+			{"location", "string"},
+			{"department", "string"},
+			{"salary", "number"},
+			{"start_date", "datetime"},
+		},
+	},
+}
+
+// Add our rows to our dataset.
+err := dataset.AddRows(rows...)
+if err != nil {
+	return err
+}
+
+// Build our query specifying preferred metrics and bucket composition.
+query := &Query{
+    Metrics: []Metric{
+        {Type: "max", Field: "salary"},
+        {Type: "min", Field: "salary"},
+    },
+    Bucket: &Bucket{
+        Field: &Field{
+            Name: "location",
+            Type: "string",
+        },
+        Sort: &SortOptions{
+            Type: "alphabetical",
+        },
+        Bucket: &Bucket{
+            Field: &Field{
+                Name: "department",
+                Type: "string",
+            },
+            Sort: &SortOptions{
+                Type: "alphabetical",
+            },
+        },
+    },
+}
+
+// Run it.
+results, err := dataset.Run(query)
+if err != nil {
+	return err
+}
+```
+
+Find a list of available [measurers here](https://github.com/snikch/aggro/blob/master/metrics.go#L15)

--- a/cell.go
+++ b/cell.go
@@ -1,0 +1,237 @@
+package aggro
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+const (
+	fieldTypeString   = "string"
+	fieldTypeNumber   = "number"
+	fieldTypeDatetime = "datetime"
+	fieldTypeBoolean  = "boolean"
+)
+
+// newCell constructs a Cell{} based on the given *Field.Type. Data being assigned to the *Field
+// must be of the same datatype as *Field.Type.
+func newCell(data, datum interface{}, field *Field) (Cell, error) {
+	var cell Cell
+
+	switch field.Type {
+	case fieldTypeString:
+		stringValue, ok := datum.(string)
+		if !ok {
+			return nil, fmt.Errorf("Expected string datatype, got %T", datum)
+		}
+		cell = &StringCell{
+			value: stringValue,
+			field: field,
+			data:  data,
+		}
+	case fieldTypeDatetime:
+		datetimeCell := &DatetimeCell{
+			field: field,
+			data:  data,
+		}
+		switch datumTyped := datum.(type) {
+		case time.Time:
+			datetimeCell.value = &datumTyped
+		case *time.Time:
+			if datumTyped == nil {
+				return nil, errors.New("Got nil *time.Time for datetime field")
+			}
+			datetimeCell.value = datumTyped
+		case string:
+			t, err := time.Parse(time.RFC3339, datumTyped)
+			if err != nil {
+				return nil, errors.New("Invalid date string passed for datetime field. RFC3339 datetime string required")
+			}
+			datetimeCell.value = &t
+		default:
+			return nil, fmt.Errorf("Expected string or time.Time, got %T", datum)
+		}
+		cell = datetimeCell
+	case fieldTypeNumber:
+		numberCell := &NumberCell{
+			field: field,
+			data:  data,
+		}
+		var d decimal.Decimal
+		switch datumTyped := datum.(type) {
+		case int:
+			d = decimal.NewFromFloat(float64(datumTyped))
+		case int32:
+			d = decimal.NewFromFloat(float64(datumTyped))
+		case int64:
+			d = decimal.NewFromFloat(float64(datumTyped))
+		case float32:
+			d = decimal.NewFromFloat(float64(datumTyped))
+		case float64:
+			d = decimal.NewFromFloat(datumTyped)
+		default:
+			return nil, fmt.Errorf("Expected number, got %T", datum)
+		}
+		numberCell.value = &d
+		cell = numberCell
+	case fieldTypeBoolean:
+		boolValue, ok := datum.(bool)
+		if !ok {
+			return nil, fmt.Errorf("Expected boolean datatype, got %T", datum)
+		}
+		booleanCell := &BooleanCell{
+			value: boolValue,
+			field: field,
+			data:  data,
+		}
+		cell = booleanCell
+	default:
+		return nil, fmt.Errorf("Unknown field type: %s", field.Type)
+	}
+	return cell, nil
+}
+
+// Cell represents data and configuration for each of our *Table.Fields.
+type Cell interface {
+	FieldDefinition() *Field
+	IsMetricable(m measurer) bool
+	MeasurableCell() MeasurableCell
+}
+
+// MeasurableCell returns the cells MeasurableCell{}.
+type MeasurableCell interface {
+	Value() interface{}
+}
+
+// NumberCell implements the Cell interface.
+type NumberCell struct {
+	value *decimal.Decimal
+	field *Field
+	data  interface{}
+}
+
+// FieldDefinition returns the field definition (name) representing the cell.
+func (cell *NumberCell) FieldDefinition() *Field {
+	return cell.field
+}
+
+// IsMetricable determines whether the measurer{} provided can be run by the cell.
+func (cell *NumberCell) IsMetricable(m measurer) bool {
+	return true
+}
+
+// Value returns the cell value.
+func (cell *NumberCell) Value() interface{} {
+	return cell.value
+}
+
+// MeasurableCell returns the cells MeasurableCell{}.
+func (cell *NumberCell) MeasurableCell() MeasurableCell {
+	return cell
+}
+
+// ValueForPeriod returns the start of a given period.
+func (cell *NumberCell) ValueForPeriod(period []interface{}) (string, error) {
+	value, err := rangeValueForPeriod(cell.value, period)
+	return value.String(), err
+}
+
+// DatetimeCell implements the Cell interface.
+type DatetimeCell struct {
+	value *time.Time
+	field *Field
+	data  interface{}
+}
+
+// FieldDefinition returns the field definition (name) representing the cell.
+func (cell *DatetimeCell) FieldDefinition() *Field {
+	return cell.field
+}
+
+// IsMetricable determines whether the measurer{} provided can be run by the cell.
+func (cell *DatetimeCell) IsMetricable(m measurer) bool {
+	return false
+}
+
+// Value returns the cell value.
+func (cell *DatetimeCell) Value() interface{} {
+	return cell.value
+}
+
+// MeasurableCell returns the cells MeasurableCell{}.
+func (cell *DatetimeCell) MeasurableCell() MeasurableCell {
+	return nil
+}
+
+// ValueForPeriod returns the start of a given period.
+func (cell *DatetimeCell) ValueForPeriod(period DatetimePeriod, location *time.Location) (string, error) {
+	return datetimeValueForPeriod(cell.value, period, location)
+}
+
+// StringCell implements the Cell{} interface.
+type StringCell struct {
+	value string
+	field *Field
+	data  interface{}
+}
+
+// FieldDefinition returns the field definition (name) representing the cell.
+func (cell *StringCell) FieldDefinition() *Field {
+	return cell.field
+}
+
+// IsMetricable determines whether the measurer{} provided can be run by the cell.
+func (cell *StringCell) IsMetricable(m measurer) bool {
+	// We allow certain metrics to run on StringCells.
+	switch m.(type) {
+	case *cardinality, *valueCount:
+		return true
+	default:
+		return false
+	}
+}
+
+// Value returns the cell value.
+func (cell *StringCell) Value() interface{} {
+	return cell.value
+}
+
+// MeasurableCell returns the cells MeasurableCell{}.
+func (cell *StringCell) MeasurableCell() MeasurableCell {
+	return cell
+}
+
+// BooleanCell implements the Cell{} interface.
+type BooleanCell struct {
+	value bool
+	field *Field
+	data  interface{}
+}
+
+// FieldDefinition returns the field definition (name) representing the cell.
+func (cell *BooleanCell) FieldDefinition() *Field {
+	return cell.field
+}
+
+// IsMetricable determines whether the measurer{} provided can be run by the cell.
+func (cell *BooleanCell) IsMetricable(m measurer) bool {
+	// We allow certain metrics to run on BooleanCells.
+	switch m.(type) {
+	case *valueCount:
+		return true
+	default:
+		return false
+	}
+}
+
+// Value returns the cell value.
+func (cell *BooleanCell) Value() interface{} {
+	return cell.value
+}
+
+// MeasurableCell returns the cells MeasurableCell{}.
+func (cell *BooleanCell) MeasurableCell() MeasurableCell {
+	return cell
+}

--- a/dataset.go
+++ b/dataset.go
@@ -1,18 +1,16 @@
 package aggro
 
 import (
-	"errors"
 	"fmt"
-	"time"
-
-	"github.com/shopspring/decimal"
 )
 
+// Dataset holds our *Table representation of *Fields and its matching Cell data.
 type Dataset struct {
 	Table *Table
 	Rows  []map[string]Cell
 }
 
+// Run executes the query against the dataset.
 func (set *Dataset) Run(query *Query) (*Resultset, error) {
 	return (&queryProcessor{
 		dataset: set,
@@ -20,6 +18,8 @@ func (set *Dataset) Run(query *Query) (*Resultset, error) {
 	}).Run()
 }
 
+// AddRows creates a Cell{} for each of our Table.Fields and ensures the cells data
+// meets the cells defined format.
 func (set *Dataset) AddRows(rows ...map[string]interface{}) error {
 	var err error
 	// Add each row.
@@ -37,7 +37,7 @@ func (set *Dataset) AddRows(rows ...map[string]interface{}) error {
 				continue
 			}
 
-			row[field.Name], err = newCell(datum, &field)
+			row[field.Name], err = newCell(data, datum, &field)
 			if err != nil {
 				return fmt.Errorf("Error adding row %d, cell %d: %s", i, j, err.Error())
 			}
@@ -45,162 +45,4 @@ func (set *Dataset) AddRows(rows ...map[string]interface{}) error {
 		set.Rows = append(set.Rows, row)
 	}
 	return nil
-}
-
-const (
-	fieldTypeString   = "string"
-	fieldTypeNumber   = "number"
-	fieldTypeDatetime = "datetime"
-)
-
-func newCell(datum interface{}, field *Field) (Cell, error) {
-	var cell Cell
-
-	switch field.Type {
-	case fieldTypeString:
-		stringValue, ok := datum.(string)
-		if !ok {
-			return nil, fmt.Errorf("Expected string datatype, got %T", datum)
-		}
-		cell = &StringCell{
-			value: stringValue,
-			field: field,
-		}
-	case fieldTypeDatetime:
-		datetimeCell := &DatetimeCell{
-			field: field,
-		}
-		switch datumTyped := datum.(type) {
-		case time.Time:
-			datetimeCell.value = &datumTyped
-		case *time.Time:
-			if datumTyped == nil {
-				return nil, errors.New("Got nil *time.Time for datetime field")
-			}
-			datetimeCell.value = datumTyped
-		case string:
-			t, err := time.Parse(time.RFC3339, datumTyped)
-			if err != nil {
-				return nil, errors.New("Invalid date string passed for datetime field. RFC3339 datetime string required.")
-			}
-			datetimeCell.value = &t
-		default:
-			return nil, fmt.Errorf("Expected string or time.Time, got %T", datum)
-		}
-		cell = datetimeCell
-	case fieldTypeNumber:
-		numberCell := &NumberCell{
-			field: field,
-		}
-		var d decimal.Decimal
-		switch datumTyped := datum.(type) {
-		case int:
-			d = decimal.NewFromFloat(float64(datumTyped))
-		case int32:
-			d = decimal.NewFromFloat(float64(datumTyped))
-		case int64:
-			d = decimal.NewFromFloat(float64(datumTyped))
-		case float32:
-			d = decimal.NewFromFloat(float64(datumTyped))
-		case float64:
-			d = decimal.NewFromFloat(datumTyped)
-		default:
-			return nil, fmt.Errorf("Expected number, got %T", datum)
-		}
-		numberCell.value = &d
-		cell = numberCell
-	default:
-		return nil, fmt.Errorf("Unknown field type: %s", field.Type)
-	}
-	return cell, nil
-}
-
-type Cell interface {
-	FieldDefinition() *Field
-	IsMetricable(m measurer) bool
-	MeasurableCell() MeasurableCell
-}
-
-type MeasurableCell interface {
-	Value() interface{}
-}
-
-type NumberCell struct {
-	value *decimal.Decimal
-	field *Field
-}
-
-func (cell *NumberCell) FieldDefinition() *Field {
-	return cell.field
-}
-
-func (cell *NumberCell) IsMetricable(m measurer) bool {
-	return true
-}
-
-func (cell *NumberCell) Value() interface{} { //*decimal.Decimal {
-	return cell.value
-}
-
-func (cell *NumberCell) MeasurableCell() MeasurableCell {
-	return cell
-}
-
-// ValueForPeriod returns the start of a given period.
-func (cell *NumberCell) ValueForPeriod(period []interface{}) (string, error) {
-	value, err := rangeValueForPeriod(cell.value, period)
-	return value.String(), err
-}
-
-type DatetimeCell struct {
-	value *time.Time
-	field *Field
-}
-
-func (cell *DatetimeCell) FieldDefinition() *Field {
-	return cell.field
-}
-
-func (cell *DatetimeCell) IsMetricable(m measurer) bool {
-	return false
-}
-
-func (cell *DatetimeCell) Value() interface{} { //*time.Time {
-	return cell.value
-}
-
-func (cell *DatetimeCell) MeasurableCell() MeasurableCell {
-	return nil
-}
-
-// ValueForPeriod returns the start of a given period.
-func (cell *DatetimeCell) ValueForPeriod(period DatetimePeriod, location *time.Location) (string, error) {
-	return datetimeValueForPeriod(cell.value, period, location)
-}
-
-type StringCell struct {
-	value string
-	field *Field
-}
-
-func (cell *StringCell) FieldDefinition() *Field {
-	return cell.field
-}
-
-func (cell *StringCell) IsMetricable(m measurer) bool {
-	// We allow certain metrics to run on StringCells.
-	switch m.(type) {
-	case *cardinality, *valueCount:
-		return true
-	default:
-		return false
-	}
-}
-
-func (cell *StringCell) Value() interface{} {
-	return cell.value
-}
-
-func (cell *StringCell) MeasurableCell() MeasurableCell {
-	return cell
 }

--- a/field.go
+++ b/field.go
@@ -1,6 +1,7 @@
 package aggro
 
+// Field represents an individual Field within our Dataset.Table.
 type Field struct {
 	Name string
-	Type string //`enum:”string,number,datetime”`
+	Type string
 }

--- a/metrics.go
+++ b/metrics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// Metric represents a type of measurement to be applied to our dataset.
 type Metric struct {
 	Type  string
 	Field string
@@ -244,7 +245,7 @@ func (a *cardinality) AddDatum(datum interface{}) {
 		a.values = map[interface{}]int{}
 	}
 
-	// Track frequency of our values within the dataset. 
+	// Track frequency of our values within the dataset.
 	switch t := datum.(type) {
 	case *decimal.Decimal:
 		floatVal, _ := t.Float64()

--- a/resultset.go
+++ b/resultset.go
@@ -5,11 +5,14 @@ import (
 	"strings"
 )
 
+// Resultset represents a complete set of result buckets and any associated errors.
 type Resultset struct {
-	Errors  []error         `json:"errors"`
-	Buckets []*ResultBucket `json:"buckets"`
+	Errors      []error         `json:"errors"`
+	Buckets     []*ResultBucket `json:"buckets"`
+	Composition []interface{}   `json:"-"`
 }
 
+// ResultBucket represents recursively built metrics for our tablular data.
 type ResultBucket struct {
 	Value        string                 `json:"value"`
 	Metrics      map[string]interface{} `json:"metrics"`
@@ -27,8 +30,8 @@ type ResultTable struct {
 
 // Concrete errors.
 var (
-	ErrTargetDepthTooLow     = fmt.Errorf("Tabulate: target depth should be 1 or above.")
-	ErrTargetDepthNotReached = fmt.Errorf("Tabulate: reached deepest bucket before hitting target depth.")
+	ErrTargetDepthTooLow     = fmt.Errorf("Tabulate: target depth should be 1 or above")
+	ErrTargetDepthNotReached = fmt.Errorf("Tabulate: reached deepest bucket before hitting target depth")
 )
 
 // Tabulate takes a Resultset and converts it to tabular data.
@@ -98,7 +101,8 @@ func buildLookup(key []string, depth, targetDepth int, table *ResultTable, looku
 			table.ColumnTitles = append(table.ColumnTitles, key[targetDepth:])
 			lookup.columnLookup[columnKey] = true
 		}
-		lookup.cells[strings.Join(key, lookupKeyDelimiter)] = bucket.Metrics
+		m := bucket.Metrics
+		lookup.cells[strings.Join(key, lookupKeyDelimiter)] = m
 		return nil
 	}
 


### PR DESCRIPTION
- [x] Updates README : Closes #8 
- [x] Added support for aggregation by fields with `boolean` datatypes
- [x] Added `composition` attribute to `Resultset` to allow us to store the raw row data used for aggregation. This data can then be used post `Run()` if needed.
- [x] Adding missing comments across the package.